### PR TITLE
🚀 chore(release): v1.11.1

### DIFF
--- a/bones
+++ b/bones
@@ -708,7 +708,7 @@ namespace Bones {
   define('WPBONES_MINIMAL_PHP_VERSION', '7.4');
 
   /* MARK: The WP Bones command line version. */
-  define('WPBONES_COMMAND_LINE_VERSION', '1.11.0');
+  define('WPBONES_COMMAND_LINE_VERSION', '1.11.1');
 
   use Bones\SemVer\Exceptions\InvalidVersionException;
   use Bones\SemVer\Version;
@@ -790,8 +790,14 @@ namespace Bones {
     {
       $arguments = $this->arguments();
 
-      // load the console kernel
-      $this->loadKernel();
+      // Load the console kernel — skip for `rename`, which is the bootstrap
+      // command that brings vendor/plugin namespaces into sync. Loading the
+      // kernel here would resolve the plugin's Console\Kernel parent class
+      // against the freshly reinstalled vendor (still on the default
+      // `WPKirk\WPBones\...` prefix) and fatal with "class not found".
+      if (!in_array('rename', $arguments, true)) {
+        $this->loadKernel();
+      }
 
       // Check WP-CLI
       $output = shell_exec('wp --info 2>&1');

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require": {
     "php": ">=8.1",
-    "wpbones/wpbones": "dev-master",
+    "wpbones/wpbones": "^1.11.1",
     "wpbones/wpkirk-helpers": "~2.0"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1754ec1de24660d6ce6f0019e7a1b23f",
+    "content-hash": "45d24d8f2cf8f69b347f0829081d8d31",
     "packages": [
         {
             "name": "eftec/bladeone",
@@ -292,23 +292,22 @@
         },
         {
             "name": "wpbones/wpbones",
-            "version": "dev-master",
+            "version": "v1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wpbones/WPBones.git",
-                "reference": "116798c042ceb20293013358189adeaad670e202"
+                "reference": "0f20ae2e0e534765957ec2fa8b21567674179022"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wpbones/WPBones/zipball/116798c042ceb20293013358189adeaad670e202",
-                "reference": "116798c042ceb20293013358189adeaad670e202",
+                "url": "https://api.github.com/repos/wpbones/WPBones/zipball/0f20ae2e0e534765957ec2fa8b21567674179022",
+                "reference": "0f20ae2e0e534765957ec2fa8b21567674179022",
                 "shasum": ""
             },
             "require": {
                 "eftec/bladeone": "^4.13",
                 "php": ">=8.1"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -349,7 +348,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-11T09:28:29+00:00"
+            "time": "2026-04-18T13:55:18+00:00"
         },
         {
             "name": "wpbones/wpkirk-helpers",
@@ -404,9 +403,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "wpbones/wpbones": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wpbones/wpkirk",
-  "version": "1.8.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wpbones/wpkirk",
-      "version": "1.8.0",
+      "version": "1.11.1",
       "license": "GPL-3.0",
       "devDependencies": {
         "@babel/core": "^7.24.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpbones/wpkirk",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "scripts": {
     "start:gulp": "gulp watch",
     "build:gulp": "gulp build",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wpbones.com/
 Tags: template, wpbones
 Requires at least: 6.2
 Tested up to: 6.6
-Stable tag: 1.11.0
+Stable tag: 1.11.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/wp-kirk.php
+++ b/wp-kirk.php
@@ -4,7 +4,7 @@
  * Plugin Name: WP Kirk Boilerplate
  * Plugin URI: https://github.com/wpbones/WPKirk-Boilerplate
  * Description: WP Bones Boilerplate WordPress plugin
- * Version: 1.11.0
+ * Version: 1.11.1
  * Requires at least: 6.2
  * Requires PHP: 7.4
  * Author: Giovambattista Fazioli


### PR DESCRIPTION
## Release v1.11.1

Align boilerplate with [WPBones framework v1.11.1](https://github.com/wpbones/WPBones/releases/tag/v1.11.1).

### Changes

- Switch `wpbones/wpbones` constraint from `dev-master` to `^1.11.1` — tracking tagged releases going forward
- Bump versions to `1.11.1`:
  - `readme.txt` → Stable tag
  - `wp-kirk.php` → Version header
  - `package.json` → version
- `composer update` pulls in WPBones v1.11.1 (includes rename bootstrap fix + displayHelp padding fix)
- Refreshed `bones` CLI copy from v1.11.1 vendor

### Downstream

Fresh deploy ZIP moved to `docs/public/wpkirk-boilerplate.zip` for WP Playground consumption.